### PR TITLE
Update viem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5477,9 +5477,9 @@
       "license": "MIT"
     },
     "node_modules/viem": {
-      "version": "2.23.10",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.23.10.tgz",
-      "integrity": "sha512-va6Wde+v96PdfzdPEspCML1MjAqe+88O8BD+R9Kun/4s5KMUNcqfHbXdZP0ZZ2Zms80styvH2pDRAqCho6TqkA==",
+      "version": "2.23.13",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.23.13.tgz",
+      "integrity": "sha512-f3RkcrzGhU79GfBb9GHUL0m3e3LUsNudXIQTFp4fit5hUGb0ew9KOYZ6cCY5d4Melj3noBy2zq0K2fV+mp+Cpg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
During development of this demo I encountered a strange issue where I could not delegate to a certain contract. When keeping everything else 100% the same but simply using a different address as the delegate, I could delegate. Thinking maybe 7702 auths have some sort of conditional, like requiring the delegate to be payable, I added a receive function to the contract, recompiled and deployed, and indeed could deploy to that address.

I created an issue on the Odyssey github [here](https://github.com/ithacaxyz/odyssey/issues/151), but after some activity in the EIP7702 telegram group, I believe this may have been an issue with the viem library. Therefore, updating viem as recommended in the group. Hopefully this is not something encountered again.