### PR TITLE
chore: up viem

### DIFF
--- a/app/api/relay/route.ts
+++ b/app/api/relay/route.ts
@@ -1,7 +1,6 @@
 import { privateKeyToAccount } from "viem/accounts";
-import { createWalletClient, http, type Hex, encodeFunctionData, createPublicClient } from "viem";
+import { createWalletClient, http, type Hex, encodeFunctionData } from "viem";
 import { odysseyTestnet } from "@/app/lib/chains";
-import { eip7702Actions } from "viem/experimental";
 import { CBSW_IMPLEMENTATION_ADDRESS, VALIDATOR_ADDRESS } from "../../lib/constants";
 import { MULTI_OWNABLE_STORAGE_ERASER_ABI } from "../../lib/abi/MultiOwnableStorageEraser";
 
@@ -33,7 +32,7 @@ const relayerWallet = createWalletClient({
   account: relayerAccount,
   chain: odysseyTestnet,
   transport: http(),
-}).extend(eip7702Actions());
+});
 
 // Helper to encode setImplementation call
 const encodeSetImplementation = (

--- a/app/components/AccountDisruption.tsx
+++ b/app/components/AccountDisruption.tsx
@@ -121,7 +121,6 @@ export function AccountDisruption({
       console.log("Target delegate:", STORAGE_ERASER_ADDRESS);
       const authorization = await userWallet.signAuthorization({
         contractAddress: STORAGE_ERASER_ADDRESS,
-        sponsor: true,
         chainId: odysseyTestnet.id,
       });
       console.log("Created authorization:", {

--- a/app/components/AccountRecovery.tsx
+++ b/app/components/AccountRecovery.tsx
@@ -132,7 +132,6 @@ export function AccountRecovery({
         // Delegate-only recovery
         const authorization = await userWallet.signAuthorization({
           contractAddress: EIP7702PROXY_TEMPLATE_ADDRESS,
-          sponsor: true,
           chainId: odysseyTestnet.id,
         });
 
@@ -198,7 +197,6 @@ export function AccountRecovery({
         // Combined recovery
         const authorization = await userWallet.signAuthorization({
           contractAddress: EIP7702PROXY_TEMPLATE_ADDRESS,
-          sponsor: true,
           chainId: odysseyTestnet.id,
         });
 

--- a/app/components/WalletManager.tsx
+++ b/app/components/WalletManager.tsx
@@ -147,7 +147,6 @@ export function WalletManager({
       setStatus("Creating authorization signature...");
       const authorization = await userWallet.signAuthorization({
         contractAddress: EIP7702PROXY_TEMPLATE_ADDRESS,
-        sponsor: (process.env.NEXT_PUBLIC_RELAYER_ADDRESS as `0x${string}`), // the relayer will submit this signature
       });
 
       // Submit the combined upgrade transaction

--- a/app/lib/wallet-utils.ts
+++ b/app/lib/wallet-utils.ts
@@ -8,7 +8,6 @@ import {
   type Hex,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-import { eip7702Actions } from "viem/experimental";
 import { secp256k1 } from "@noble/curves/secp256k1";
 import { hexToBytes } from "@noble/curves/abstract/utils";
 import { odysseyTestnet } from "./chains";
@@ -29,7 +28,7 @@ export function createEOAClient(account: ExtendedAccount) {
     account,
     chain: odysseyTestnet,
     transport: http(),
-  }).extend(eip7702Actions());
+  });
 }
 
 // Creates a new extended account with a random private key

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "next": "14.2.15",
         "react": "^18",
         "react-dom": "^18",
-        "viem": "^2.23.0"
+        "viem": "^2.24.1"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -5477,9 +5477,9 @@
       "license": "MIT"
     },
     "node_modules/viem": {
-      "version": "2.23.13",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.23.13.tgz",
-      "integrity": "sha512-f3RkcrzGhU79GfBb9GHUL0m3e3LUsNudXIQTFp4fit5hUGb0ew9KOYZ6cCY5d4Melj3noBy2zq0K2fV+mp+Cpg==",
+      "version": "2.24.1",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.24.1.tgz",
+      "integrity": "sha512-xptFlc081SIPz+ZNDeb0XS/Nn5PU28onq+im+UxEAPCXTIuL1kfw1GTnV8NhbUNoEONnrwcZNqoI0AT0ADF5XQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -6,14 +6,15 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "types": "tsc --noEmit"
   },
   "dependencies": {
     "ethereum-cryptography": "^3.0.0",
     "next": "14.2.15",
     "react": "^18",
     "react-dom": "^18",
-    "viem": "^2.23.0"
+    "viem": "^2.24.1"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
EIP-7702 in Viem is now stable as of `viem@2.24`. This PR updates to the latest Viem and uses the stabilized APIs.